### PR TITLE
Monolog entries are duplicated with multiple Guzzle Clients

### DIFF
--- a/src/DependencyInjection/Compiler/MonologCompilerPass.php
+++ b/src/DependencyInjection/Compiler/MonologCompilerPass.php
@@ -16,16 +16,16 @@ class MonologCompilerPass implements CompilerPassInterface
             return;
         }
 
+        $bundleStack = $container->findDefinition('emoe_guzzle.handler_stack');
         $monologMiddleware = $container->findDefinition('emoe_guzzle.request_monolog_middleware');
+        $monologMiddleware->addMethodCall('attachMiddleware', [$bundleStack]);
 
         foreach (array_keys($container->findTaggedServiceIds('guzzle.client')) as $id) {
             $definition = $container->getDefinition($id);
             $arguments = $definition->getArguments();
             if (!isset($arguments[0]['handler'])) {
-                continue;
+                $arguments[0]['handler'] = $bundleStack;
             }
-            $stack = $arguments[0]['handler'];
-            $monologMiddleware->addMethodCall('attachMiddleware', [$stack]);
             $arguments[0]['monolog_middleware'] = $monologMiddleware;
             $definition->setArguments($arguments);
         }


### PR DESCRIPTION
## Description
If you have Monolog logging enabled and are using multiple named clients, this bundle will duplicate a log entry for each service tagged "guzzle.client". This PR addresses that by changing how the middleware attaches to the stack handler.

## To Recreate:
Create multiple clients in your definition (per the documentation):
```
services:
    guzzle.client_one:
        class: %guzzle.client.class%
        tags:
            - { name: guzzle.client }

    guzzle.client_two:
        class: %guzzle.client.class%
        tags:
            - { name: guzzle.client }
```

Use any Guzzle client to send a request and review your Monolog entries. You will see the same number of duplicate messages as the number of clients you have tagged. (Notice that the Guzzle log does not duplicate messages.)

## Reason:
When iterating over the tagged services all tagged services contain the same reference to their handler (assigned in the `ClientCompilerPass.php`). We are then attaching that handler multiple times to the same instance of the Monolog middleware. This results in the Guzzle log entry being sent into the handler multiple times.

## Fix:
Only attach the handler stack to the middlware once. Still assign the middleware and handler to each tagged client.