### PR TITLE
Address Typo in Profiler template file

### DIFF
--- a/src/Resources/views/Collector/nextgen.html.twig
+++ b/src/Resources/views/Collector/nextgen.html.twig
@@ -60,7 +60,7 @@
             <p>No requests sent.</p>
         </div>
     {% else %}
-        {% set methods = ['GET', 'POST', 'PUT', 'DELTE', 'OTHER'] %}
+        {% set methods = ['GET', 'POST', 'PUT', 'DELETE', 'OTHER'] %}
         {# sort collected logs in groups #}
         {% set groups = {} %}
         {% for request in collector.requests %}


### PR DESCRIPTION
Pull Request for #14 

> When a Guzzle DELETE request is captured and displayed in the profiler, it is put in the "OTHER" tab, instead of "DELETE".